### PR TITLE
Pruebas HU01 Y HU02 Espresso

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="-1585833809">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_36" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1802459644">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_36" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1840381580">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_36" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,15 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="AlbumFlowTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="AlbumListTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="AlbumDetailTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ El backend utiliza PostgreSQL como base de datos. Asegúrate de tener configurad
 
 ## 🧪 Ejecución de pruebas
 
+Para el caso de las pruebas realizadas con Espresso, se puede ejecutar haciendo uso de la interfaz de android studio haciendo clic en las botones de ejecición ▶️ mostrados en la siguiente imagen:
+![image](https://github.com/user-attachments/assets/44411700-5083-4001-9604-c80871aaf9b5)
+
 ## 💻 Tecnologías utilizadas
 
 - Jetpack Compose: Framework moderno para UI declarativa

--- a/app/src/androidTest/java/com/example/vinilos/ui/activities/AlbumDetailTest.kt
+++ b/app/src/androidTest/java/com/example/vinilos/ui/activities/AlbumDetailTest.kt
@@ -1,0 +1,71 @@
+package com.example.vinilos.ui.activities
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.vinilos.ui.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AlbumDetailTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun test_navigateToAlbumDetailAndVerifyContent() {
+        // Esperar a que carguen los álbumes en la pantalla principal
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Hacer clic en el primer álbum
+        composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)[0].performClick()
+
+        // Esperar a que cargue la pantalla de detalle
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onNodeWithText("Detalle de Álbum").assertExists()
+            true
+        }
+
+        // Verificar que los elementos principales del detalle están presentes
+        composeTestRule.onNodeWithText("Información").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Tracks").assertIsDisplayed()
+
+        // Verificar que el botón de regresar está disponible
+        composeTestRule.onNodeWithContentDescription("Regresar").assertIsDisplayed()
+    }
+
+    @Test
+    fun test_returnFromAlbumDetail() {
+        // Esperar a que carguen los álbumes en la pantalla principal
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Hacer clic en el primer álbum
+        composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)[0].performClick()
+
+        // Esperar a que cargue la pantalla de detalle
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onNodeWithText("Detalle de Álbum").assertExists()
+            true
+        }
+
+        // Presionar el botón de retorno
+        composeTestRule.onNodeWithContentDescription("Regresar").performClick()
+
+        // Verificar que hemos regresado a la pantalla principal
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onNodeWithText("VinylWave").assertExists()
+            true
+        }
+
+        // Confirmar que estamos en la lista de álbumes de nuevo
+        composeTestRule.onNodeWithText("Álbumes").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/example/vinilos/ui/activities/AlbumFlowTest.kt
+++ b/app/src/androidTest/java/com/example/vinilos/ui/activities/AlbumFlowTest.kt
@@ -1,0 +1,79 @@
+package com.example.vinilos.ui.activities
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.example.vinilos.ui.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class AlbumFlowTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun test_completeAlbumFlow() {
+        // 1. Esperar a que cargue la lista de álbumes (HU01)
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verificar elementos de la pantalla de álbumes
+        composeTestRule.onNodeWithText("VinylWave").assertIsDisplayed()
+
+        // Obtener el número de álbumes para verificaciones posteriores
+        val albumNodes = composeTestRule.onAllNodesWithContentDescription(
+            label = "Portada de",
+            substring = true
+        ).fetchSemanticsNodes()
+
+        assert(albumNodes.isNotEmpty()) { "No se encontraron álbumes en la pantalla" }
+
+        // 2. Navegar al detalle del primer álbum (HU02)
+        composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)[0].performClick()
+
+        // 3. Verificar el contenido de la pantalla de detalle
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithText("Información").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithText("Información").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Tracks").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Detalle de Álbum").assertIsDisplayed()
+
+        // 4. Verificar opción de regresar y usarla
+        composeTestRule.onNodeWithContentDescription("Regresar").performClick()
+
+        // 5. Verificar que hemos regresado a la lista de álbumes
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun test_errorHandlingAndRetry() {
+        // Este test simula una situación donde podríamos tener un error
+        // Si la aplicación muestra un error (lo que puede suceder si el servidor no está disponible)
+        if (composeTestRule.onAllNodesWithText("Reintentar").fetchSemanticsNodes().isNotEmpty()) {
+            // Probar la funcionalidad de reintentar
+            composeTestRule.onNodeWithText("Reintentar").performClick()
+
+            // Esperar a que se carguen los datos
+            composeTestRule.waitForIdle()
+
+            // Verificar si se recuperó después del error
+            composeTestRule.waitUntil(timeoutMillis = 10000) {
+                composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)
+                    .fetchSemanticsNodes().isNotEmpty() ||
+                        composeTestRule.onAllNodesWithText("Reintentar").fetchSemanticsNodes().isNotEmpty()
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/example/vinilos/ui/activities/AlbumListTest.kt
+++ b/app/src/androidTest/java/com/example/vinilos/ui/activities/AlbumListTest.kt
@@ -1,0 +1,105 @@
+package com.example.vinilos.ui.activities
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.vinilos.ui.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AlbumListTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun test_albumsAreDisplayed() {
+        // Esperamos a que desaparezca la pantalla de carga y se muestren los álbumes
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verificamos que se muestra al menos un álbum
+        val nodes = composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)
+            .fetchSemanticsNodes()
+        assert(nodes.size >= 1) { "Se esperaba al menos 1 álbum, pero se encontraron ${nodes.size}" }
+
+        // Verificamos que no hay error en la pantalla
+        composeTestRule.onNodeWithText("Error").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Reintentar").assertDoesNotExist()
+    }
+
+    @Test
+    fun test_navigationTabsAreDisplayed() {
+        // Verificamos que los tabs de navegación están presentes
+        composeTestRule.onNodeWithText("Álbumes").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Artistas").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Coleccionistas").assertIsDisplayed()
+    }
+
+    @Test
+    fun test_appTitleIsDisplayed() {
+        // Verificamos que el título de la app está visible
+        composeTestRule.onNodeWithText("VinylWave").assertIsDisplayed()
+    }
+
+    @Test
+    fun test_navigateThroughAllAlbums() {
+        // Esperar a que carguen los álbumes
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Obtener todos los álbumes disponibles
+        val albumNodes = composeTestRule.onAllNodesWithContentDescription(
+            label = "Portada de",
+            substring = true
+        ).fetchSemanticsNodes()
+
+        val totalAlbums = albumNodes.size
+
+        // Navegar por cada uno de los álbumes
+        for (i in 0 until totalAlbums) {
+            // Verificar que estamos en la pantalla principal
+            composeTestRule.onNodeWithText("VinylWave").assertIsDisplayed()
+
+            // Esperar a que los álbumes estén cargados (por si acaso)
+            composeTestRule.waitUntil(timeoutMillis = 5000) {
+                composeTestRule.onAllNodesWithContentDescription(label = "Portada de", substring = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }
+
+            // Verificar que podemos acceder al álbum actual
+            composeTestRule.onAllNodesWithContentDescription(
+                label = "Portada de",
+                substring = true
+            )[i].assertExists()
+
+            // Hacer clic en el álbum actual
+            composeTestRule.onAllNodesWithContentDescription(
+                label = "Portada de",
+                substring = true
+            )[i].performClick()
+
+            // Verificar que estamos en la pantalla de detalle
+            composeTestRule.waitUntil(timeoutMillis = 10000) {
+                composeTestRule.onNodeWithText("Detalle de Álbum").assertExists()
+                true
+            }
+
+            // Verificar elementos característicos de la pantalla de detalle
+            composeTestRule.onNodeWithText("Información").assertIsDisplayed()
+            composeTestRule.onNodeWithText("Tracks").assertIsDisplayed()
+
+            // Regresar a la lista de álbumes
+            composeTestRule.onNodeWithContentDescription("Regresar").performClick()
+        }
+
+        // Verificar que hemos terminado en la pantalla principal
+        composeTestRule.onNodeWithText("VinylWave").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
Este pull request introduce varias actualizaciones relacionadas con las pruebas de interfaz de usuario de Android, archivos de configuración y documentación. Los cambios más notables incluyen la adición de nuevas pruebas de interfaz de usuario para las características relacionadas con el álbum, las actualizaciones de los archivos de configuración del proyecto IntelliJ IDEA, y mejoras en la documentación README para la ejecución de pruebas.

### Android UI Tests:
* **Nuevas pruebas para los detalles del álbum y la navegación**: Añadidas `AlbumDetailTest`, `AlbumFlowTest`, y `AlbumListTest` para validar interacciones UI como la navegación a detalles del álbum, manejo de errores, y verificación de listas de álbumes y pestañas de navegación. Estas pruebas utilizan las utilidades de prueba de Jetpack Compose. 

### Actualizaciones de la configuración de IntelliJ IDEA:
* **Preferencias de resultados de pruebas**: Añadido `.idea/androidTestResultsUserPreferences.xml` para definir los anchos de columna preferidos para los resultados de las pruebas en Android Studio.
* **Selector de destino de despliegue**: Actualizado `.idea/deploymentTargetSelector.xml` para incluir nuevas configuraciones de prueba (`AlbumFlowTest`, `AlbumListTest`, y `AlbumDetailTest`).
* **Ajustes varios del proyecto**: Ajustes menores en `.idea/misc.xml`, como la eliminación de la línea de declaración XML.

### Documentación:
* Instrucciones de ejecución de las pruebas: Mejorado `README.md` con instrucciones para ejecutar las pruebas de Espresso a través de la interfaz de Android Studio, incluyendo un ejemplo visual.