### PR TITLE
Se implementan pruebas espresso para las HU03, HU04 y HU05

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -16,6 +16,45 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1399008292">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Small_Phone" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-846553958">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Small_Phone" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1295030927">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Small_Phone" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1802459644">
           <value>
             <AndroidTestResultsTableState>
@@ -23,6 +62,7 @@
                 <map>
                   <entry key="Duration" value="90" />
                   <entry key="Medium_Phone_API_36" value="120" />
+                  <entry key="Small_Phone" value="120" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,18 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="AlbumListTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="ArtistListTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="ArtistDetailTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="CollectorListTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/androidTest/java/com/example/vinilos/ui/activities/ArtistDetailTest.kt
+++ b/app/src/androidTest/java/com/example/vinilos/ui/activities/ArtistDetailTest.kt
@@ -1,0 +1,76 @@
+package com.example.vinilos.ui.activities
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.vinilos.ui.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ArtistDetailTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun test_navigateToArtistDetailAndVerifyContent() {
+        // Navegar a la pestaña de artistas
+        composeTestRule.onNodeWithText("Artistas").performClick()
+
+        // Esperar a que cargue la lista de artistas
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithTag("artist_item")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Hacer clic en el primer artista
+        composeTestRule.onAllNodesWithTag("artist_item")[0].performClick()
+
+        // Esperar a que cargue la pantalla de detalle
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithText("Detalle de Artista")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verificar que los elementos principales del detalle están presentes
+        composeTestRule.onNodeWithText("Información").assertIsDisplayed()
+
+        // Verificar que hay una sección de álbumes (si el artista tiene álbumes)
+        composeTestRule.onNodeWithText("Álbumes").assertIsDisplayed()
+
+        // Verificar que el botón de regresar está disponible
+        composeTestRule.onNodeWithContentDescription("Regresar").assertIsDisplayed()
+    }
+
+    @Test
+    fun test_returnFromArtistDetail() {
+        // Navegar a la pestaña de artistas
+        composeTestRule.onNodeWithText("Artistas").performClick()
+
+        // Esperar a que cargue la lista de artistas
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithTag("artist_item")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Hacer clic en el primer artista
+        composeTestRule.onAllNodesWithTag("artist_item")[0].performClick()
+
+        // Esperar a que cargue la pantalla de detalle
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithText("Detalle de Artista")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Presionar el botón de retorno
+        composeTestRule.onNodeWithContentDescription("Regresar").performClick()
+
+        // Verificar que hemos regresado a la lista de artistas
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onNodeWithText("Artistas").isDisplayed() &&
+                    composeTestRule.onAllNodesWithTag("artist_item").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/example/vinilos/ui/activities/ArtistListTest.kt
+++ b/app/src/androidTest/java/com/example/vinilos/ui/activities/ArtistListTest.kt
@@ -1,0 +1,75 @@
+package com.example.vinilos.ui.activities
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.vinilos.ui.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ArtistListTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun test_artistsTabIsAccessible() {
+        // Verificar que estamos en la pantalla principal
+        composeTestRule.onNodeWithText("VinylWave").assertIsDisplayed()
+
+        // Hacer clic en la pestaña de artistas
+        composeTestRule.onNodeWithText("Artistas").performClick()
+
+        // Esperar a que cargue la lista de artistas
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithTag("artist_item")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun test_artistsAreDisplayed() {
+        // Navegar a la pestaña de artistas
+        composeTestRule.onNodeWithText("Artistas").performClick()
+
+        // Esperar a que cargue la lista de artistas
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithTag("artist_item")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verificar que se muestra al menos un artista
+        val nodes = composeTestRule.onAllNodesWithTag("artist_item").fetchSemanticsNodes()
+        assert(nodes.isNotEmpty()) { "Se esperaba al menos 1 artista, pero se encontraron ${nodes.size}" }
+
+        // Verificar que no hay error en la pantalla
+        composeTestRule.onNodeWithText("Error").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Reintentar").assertDoesNotExist()
+    }
+
+    @Test
+    fun test_navigateToArtistDetail() {
+        // Navegar a la pestaña de artistas
+        composeTestRule.onNodeWithText("Artistas").performClick()
+
+        // Esperar a que cargue la lista de artistas
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithTag("artist_item")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Hacer clic en el primer artista
+        composeTestRule.onAllNodesWithTag("artist_item")[0].performClick()
+
+        // Verificar que estamos en la pantalla de detalle
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithText("Detalle de Artista")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Regresar a la lista
+        composeTestRule.onNodeWithContentDescription("Regresar").performClick()
+    }
+}

--- a/app/src/androidTest/java/com/example/vinilos/ui/activities/CollectorListTest.kt
+++ b/app/src/androidTest/java/com/example/vinilos/ui/activities/CollectorListTest.kt
@@ -1,0 +1,75 @@
+package com.example.vinilos.ui.activities
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.vinilos.ui.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CollectorListTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun test_collectorsTabIsAccessible() {
+        // Verificar que estamos en la pantalla principal
+        composeTestRule.onNodeWithText("VinylWave").assertIsDisplayed()
+
+        // Hacer clic en la pestaña de coleccionistas
+        composeTestRule.onNodeWithText("Coleccionistas").performClick()
+
+        // Esperar a que cargue la lista de coleccionistas
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithTag("collector_item")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun test_collectorsAreDisplayed() {
+        // Navegar a la pestaña de coleccionistas
+        composeTestRule.onNodeWithText("Coleccionistas").performClick()
+
+        // Esperar a que cargue la lista de coleccionistas
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithTag("collector_item")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verificar que se muestra al menos un coleccionista
+        val nodes = composeTestRule.onAllNodesWithTag("collector_item").fetchSemanticsNodes()
+        assert(nodes.size >= 1) { "Se esperaba al menos 1 coleccionista, pero se encontraron ${nodes.size}" }
+
+        // Verificar que no hay error en la pantalla
+        composeTestRule.onNodeWithText("Error").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Reintentar").assertDoesNotExist()
+    }
+
+    @Test
+    fun test_collectorItemClick() {
+        // Navegar a la pestaña de coleccionistas
+        composeTestRule.onNodeWithText("Coleccionistas").performClick()
+
+        // Esperar a que cargue la lista de coleccionistas
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
+            composeTestRule.onAllNodesWithTag("collector_item")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verificar que podemos hacer clic en un coleccionista (pero sin esperar navegación)
+        // Esto solo verifica que el componente es clicable
+        composeTestRule.onAllNodesWithTag("collector_item")[0].assertHasClickAction()
+
+        // Opcionalmente, podemos hacer clic para ver que no hay crash
+        composeTestRule.onAllNodesWithTag("collector_item")[0].performClick()
+
+        // Verificar que seguimos en la lista de coleccionistas
+        composeTestRule.waitUntil(timeoutMillis = 2000) {
+            composeTestRule.onAllNodesWithTag("collector_item").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+}

--- a/app/src/main/java/com/example/vinilos/ui/components/artists/ArtistCard.kt
+++ b/app/src/main/java/com/example/vinilos/ui/components/artists/ArtistCard.kt
@@ -26,6 +26,7 @@ import com.example.vinilos.models.Artist
 import com.example.vinilos.ui.theme.CoveDarkBlue
 import com.example.vinilos.ui.theme.CoveLightBlue
 import com.example.vinilos.ui.theme.CoveOrange
+import androidx.compose.ui.platform.testTag
 
 @Composable
 fun ArtistCard(
@@ -36,6 +37,7 @@ fun ArtistCard(
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .testTag("artist_item")
             .clickable(onClick = onClick),
         elevation = CardDefaults.cardElevation(2.dp),
         shape = MaterialTheme.shapes.medium,

--- a/app/src/main/java/com/example/vinilos/ui/components/collectors/CollectorItem.kt
+++ b/app/src/main/java/com/example/vinilos/ui/components/collectors/CollectorItem.kt
@@ -27,6 +27,8 @@ import com.example.vinilos.models.Collector
 import com.example.vinilos.ui.theme.CoveDarkBlue
 import com.example.vinilos.ui.theme.CoveLightBlue
 import com.example.vinilos.ui.theme.CoveOrange
+import androidx.compose.ui.platform.testTag
+
 
 @Composable
 fun CollectorItem(
@@ -37,6 +39,7 @@ fun CollectorItem(
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .testTag("collector_item")
             .clickable(onClick = onClick),
         elevation = CardDefaults.cardElevation(2.dp),
         shape = MaterialTheme.shapes.medium,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.2"
+agp = "8.10.0"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
Este pull request introduce varios cambios, centrados principalmente en mejorar las pruebas de interfaz de usuario de la aplicación, añadir etiquetas de prueba a los componentes y actualizar las dependencias. A continuación se muestra un resumen de los cambios más importantes agrupados por temas:

### Mejoras en las pruebas de interfaz de usuario
* Se han añadido nuevas clases de pruebas de interfaz de usuario: `ArtistDetailTest`, `ArtistListTest` y `CollectorListTest` para validar la navegación y la representación del contenido para artistas y coleccionistas. Estas pruebas garantizan que se muestren y se pueda hacer clic en los elementos correctos de la interfaz de usuario, y verifican la navegación entre pantallas. 
* Se han actualizado los componentes `ArtistCard` y `CollectorItem` para incluir atributos `testTag` que facilitan la identificación en las pruebas de interfaz de usuario. 

### Actualizaciones de configuración
* Modificado `.idea/androidTestResultsUserPreferences.xml` para incluir nuevas configuraciones de resultados de pruebas para dispositivos y columnas adicionales.
* Actualizado `.idea/deploymentTargetSelector.xml` para añadir configuraciones de destino de despliegue para los nuevos casos de prueba. 
### Actualizaciones de dependencias
* Actualizada la versión de Android Gradle Plugin (AGP) de `8.9.2` a `8.10.0` en `gradle/libs.versions.toml`. 